### PR TITLE
2.0.0

### DIFF
--- a/CaedendiSimpleLootFilter/mod.js
+++ b/CaedendiSimpleLootFilter/mod.js
@@ -2,6 +2,7 @@
 ////=============================================////
 ////                                             ////
 ////   Caedendi's Simple Loot Filter for D2RMM   ////
+////                   v2.0.0                    ////
 ////                                             ////
 ////=============================================////
 ////=============================================////
@@ -11,15 +12,19 @@
 //===============//
 
 // File paths
-const profileHdPath = 'global\\ui\\layouts\\_profilehd.json';
+const FILE_EXTENSION_JSON = ".json";
 
-const itemNameAffixesPath = 'local\\lng\\strings\\item-nameaffixes.json';
-const itemNamesPath = 'local\\lng\\strings\\item-names.json';
-const itemRunesPath = 'local\\lng\\strings\\item-runes.json';
-const uiPath = 'local\\lng\\strings\\ui.json';
+const FILE_PROFILE_HD_PATH = `global\\ui\\layouts\\_profilehd${FILE_EXTENSION_JSON}`;
+
+const FILE_PATH_STRINGS          = "local\\lng\\strings\\";
+const FILE_ITEM_MODIFIERS_PATH   = `${FILE_PATH_STRINGS}item-modifiers${FILE_EXTENSION_JSON}`;
+const FILE_ITEM_NAMEAFFIXES_PATH = `${FILE_PATH_STRINGS}item-nameaffixes${FILE_EXTENSION_JSON}`;
+const FILE_ITEM_NAMES_PATH       = `${FILE_PATH_STRINGS}item-names${FILE_EXTENSION_JSON}`;
+const FILE_ITEM_RUNES_PATH       = `${FILE_PATH_STRINGS}item-runes${FILE_EXTENSION_JSON}`;
+const FILE_ITEM_UI_PATH          = `${FILE_PATH_STRINGS}ui${FILE_EXTENSION_JSON}`;
 
 // Color
-const COLOR_PREFIX = 'ÿc';
+const COLOR_PREFIX = "ÿc";
 
 const WHITE = `${COLOR_PREFIX}0`;
 const WHITE1 = `${COLOR_PREFIX}=`;
@@ -65,21 +70,31 @@ const HIDDEN = '' + ' '.repeat(config.HiddenItemTooltipSize);
 //=============//
 //   Affixes   //
 //=============//
+
+// Gold
 const customAffixes = {
+  items: {},
 
-  //==========//
-  //   Gold   //
-  //==========//
-  gld: `${GOLD1}G`, // Gold displays as "1234 G" with white numbers and gold-colored G.
+  customizeGold() {
+    this.items.gld = `${GOLD1}G`; // Gold displays as "1234 G" with white numbers and gold-colored G.
+  },
+  
+  // Gems - For some reason, the devs put these gems in the wrong JSON file.
+  customizeGems() {
+    this.items.gsw = `${WHITE}o ${WHITE}Diamond`;  // Diamond
+    this.items.gsg = `${GREEN}o ${WHITE}Emerald`;  // Emerald
+    this.items.gsr =   `${RED}o ${WHITE}Ruby`;     // Ruby
+    this.items.gsb =  `${BLUE}o ${WHITE}Sapphire`; // Sapphire
+  },
 
-  //==========//
-  //   Gems   //
-  //==========//
-  // For some reason, the devs put these gems in the wrong JSON file.
-  gsw: `${WHITE}o ${WHITE}Diamond`,  // Diamond
-  gsg: `${GREEN}o ${WHITE}Emerald`,  // Emerald
-  gsr:   `${RED}o ${WHITE}Ruby`,     // Ruby
-  gsb:  `${BLUE}o ${WHITE}Sapphire`, // Sapphire
+  // Superior/Inferior Prefixes
+  customizeSupInf() {
+    this.items["Hiquality"]   = `+`;
+    this.items["Damaged"]     = `-`;
+    this.items["Cracked"]     = `-`;
+    this.items["Low Quality"] = `-`;
+    this.items["Crude"]       = `-`;
+  },
 };
 
 
@@ -94,233 +109,329 @@ const customRunes = {
   /* Eth   */ r05: `${ORANGE1}Eth (5)`,
   /* Ith   */ r06: `${ORANGE1}Ith (6)`,
   /* Tal   */ r07: `${ORANGE1}Tal (7)`,
-  /* Ral   */ r08: `${RED}**${ORANGE1}  Ral (8)  ${RED}**${ORANGE1}`,
+  /* Ral   */ r08: `${RED}*****${ORANGE1}   Ral (8)   ${RED}*****${ORANGE1}`,
   /* Ort   */ r09: `${ORANGE1}Ort (9)`,
   /* Thul  */ r10: `${ORANGE1}Thul (10)`,
   /* Amn   */ r11: `${ORANGE1}Amn (11)`,
   /* Sol   */ r12: `${ORANGE1}Sol (12)`,
   /* Shael */ r13: `${ORANGE1}Shael (13)`,
   /* Dol   */ r14: `${ORANGE1}Dol (14)`,
-  /* Hel   */ r15: `${RED}**${ORANGE1}  Hel (15) ${RED}**${ORANGE1}`,
-  /* Io    */ r16: `${ORANGE1}Io (16)`,
-  /* Lum   */ r17: `${ORANGE1}Lum (17)`,
-  /* Ko    */ r18: `${RED}**${ORANGE1}  Ko (18)  ${RED}**${ORANGE1}`,
-  /* Fal   */ r19: `${RED}**${ORANGE1}  Fal (19)  ${RED}**${ORANGE1}`,
-  /* Lem   */ r20: `${RED}**${ORANGE1}  Lem (20)  ${RED}**${ORANGE1}`,
-  /* Pul   */ r21: `${RED}*****${ORANGE1}   Pul (21)   ${RED}*****${ORANGE1}`,
-  /* Um    */ r22: `${RED}*****${ORANGE1}   Um (22)   ${RED}*****${ORANGE1}`,
-  /* Mal   */ r23: `${RED}*****${ORANGE1}   Mal (23)   ${RED}*****${ORANGE1}`,
-  /* Ist   */ r24: `${RED}*****${ORANGE1}   Ist (24)   ${RED}*****${ORANGE1}`,
-  /* Gul   */ r25: `${RED}*****${ORANGE1}   Gul (25)   ${RED}*****${ORANGE1}`,
-  /* Vex   */ r26: `${RED}**********${ORANGE1}     Vex (26)     ${RED}**********${ORANGE1}`,
-  /* Ohm   */ r27: `${RED}**********${ORANGE1}     Ohm (27)     ${RED}**********${ORANGE1}`,
-  /* Lo    */ r28: `${RED}**********${ORANGE1}     Lo (28)     ${RED}**********${ORANGE1}`,
-  /* Sur   */ r29: `${RED}**********${ORANGE1}     Sur (29)     ${RED}**********${ORANGE1}`,
-  /* Ber   */ r30: `${RED}**********${ORANGE1}     Ber (30)     ${RED}**********${ORANGE1}`,
-  /* Jah   */ r31: `${RED}**********${ORANGE1}     Jah (31)     ${RED}**********${ORANGE1}`,
-  /* Cham  */ r32: `${RED}**********${ORANGE1}     Cham (32)     ${RED}**********${ORANGE1}`,
-  /* Zod   */ r33: `${RED}**********${ORANGE1}     Zod (33)     ${RED}**********${ORANGE1}`,
+  /* Hel   */ r15: `${RED}*****${ORANGE1}   Hel (15)   ${RED}*****${ORANGE1}`,
+  /* Io    */ r16: `${RED}*****${ORANGE1}   Io (16)   ${RED}*****${ORANGE1}`,
+  /* Lum   */ r17: `${RED}*****${ORANGE1}   Lum (17)   ${RED}*****${ORANGE1}`,
+  /* Ko    */ r18: `${RED}*****${ORANGE1}   Ko (18)   ${RED}*****${ORANGE1}`,
+  /* Fal   */ r19: `${RED}*****${ORANGE1}   Fal (19)   ${RED}*****${ORANGE1}`,
+  /* Lem   */ r20: `${RED}**********${ORANGE1}     Lem ${RED}(20)     **********${ORANGE1}`,
+  /* Pul   */ r21: `${RED}**********${ORANGE1}     Pul ${RED}(21)     **********${ORANGE1}`,
+  /* Um    */ r22: `${RED}**********${ORANGE1}     Um ${RED}(22)     **********${ORANGE1}`,
+  /* Mal   */ r23: `${RED}**********${ORANGE1}     Mal ${RED}(23)     **********${ORANGE1}`,
+  /* Ist   */ r24: `${RED}**********${ORANGE1}     Ist ${RED}(24)     **********${ORANGE1}`,
+  /* Gul   */ r25: `${RED}**********${ORANGE1}     Gul ${RED}(25)     **********${ORANGE1}`,
+  /* Vex   */ r26: `${RED}********** ********** **********     Vex (26)     ********** ********** **********`,
+  /* Ohm   */ r27: `${RED}********** ********** **********     Ohm (27)     ********** ********** **********`,
+  /* Lo    */ r28: `${RED}********** ********** **********     Lo (28)     ********** ********** **********`,
+  /* Sur   */ r29: `${RED}********** ********** **********     Sur (29)     ********** ********** **********`,
+  /* Ber   */ r30: `${RED}********** ********** **********     Ber (30)     ********** ********** **********`,
+  /* Jah   */ r31: `${RED}********** ********** **********     Jah (31)     ********** ********** **********`,
+  /* Cham  */ r32: `${RED}********** ********** **********     Cham (32)     ********** ********** **********`,
+  /* Zod   */ r33: `${RED}********** ********** **********     Zod (33)     ********** ********** **********`,
 };
 
 
 //==================//
 //   Custom Items   //
 //==================//
-const customItems = {
+const customItemNames = {
 
-  //=============//
-  //   Potions   //
-  //=============//
-  hp1: `${RED}+${WHITE}HP1`, // Minor Healing Potion
-  hp2: `${RED}+${WHITE}HP2`, // Light Healing Potion
-  hp3: `${RED}+${WHITE}HP3`, // Healing Potion
-  hp4: `${RED}+${WHITE}HP4`, // Greater Healing Potion
-  hp5: `${RED}+${WHITE}HP5`, // Super Healing Potion
-
-  mp1: `${BLUE}+${WHITE}MP1`, // Minor Mana Potion
-  mp2: `${BLUE}+${WHITE}MP2`, // Light Mana Potion
-  mp3: `${BLUE}+${WHITE}MP3`, // Mana Potion
-  mp4: `${BLUE}+${WHITE}MP4`, // Greater Mana Potion
-  mp5: `${BLUE}+${WHITE}MP5`, // Super Mana Potion
-  
-  rvs: `${PURPLE}+${WHITE}RPS`, // Rejuvenation Potion
-  rvl: `${PURPLE}+${WHITE}RPF`, // Full Rejuvenation Potion
-  
-  yps: `${GREEN}+${WHITE}Antidote`, // Antidote Potion
-  wms: `${GREEN}+${WHITE}Thawing`, // Thawing Potion
-  vps: `${GREEN}+${WHITE}Stamina`, // Stamina Potion
+  items: {},
 
   //==========//
   //   Junk   //
   //==========//
-  tbk: `${GREEN}+${WHITE}TP Tome`, // Tome of Town Portal
-  ibk: `${GREEN}+${WHITE}ID Tome`, // Tome of Identify
-  tsc: `${GREEN}+${WHITE}TP`,      // Scroll of Town Portal
-  isc: `${GREEN}+${WHITE}ID`,      // Scroll of Identify
-
-  gpl: `${DARKGREEN1}o${WHITE} Gas 1`, // Strangling Gas Potion
-  gpm: `${DARKGREEN1}o${WHITE} Gas 2`, // Fulminating Potion
-  gps: `${DARKGREEN1}o${WHITE} Gas 3`, // Choking Gas Potion
-
-  opl: `${ORANGE}o${WHITE} Oil 1`, // Exploding Potion
-  opm: `${ORANGE}o${WHITE} Oil 2`, // Rancid Gas Potion
-  ops: `${ORANGE}o${WHITE} Oil 3`, // Oil Potion
-
-  aqv: `${GRAY}o${WHITE} Arrows`, // Arrow Quiver
-  cqv: `${GRAY}o${WHITE} Bolts`, // Crossbow Bolt Quiver
-
-  // key: HIDDEN, // Regular key for locked chests
-
-  //=============//
-  //   Jewelry   //   BUGGED: crafted/rare/set/unique jewelry and charms show up as blue
-  //=============//
-  // amu: `${RED}0 ${BLUE}Amulet ${RED}0${BLUE}`, // Amulet
-  // rin: `${RED}0 ${BLUE}Ring ${RED}0${BLUE}`,   // Ring
-  // jew: `${RED}0 ${BLUE}Jewel ${RED}0${BLUE}`,  // Jewel
-
-  // cm1: `${RED}0 ${BLUE}Small Charm ${RED}0${BLUE}`, // Small Charm
-  // cm2: `${RED}0 ${BLUE}Large Charm ${RED}0${BLUE}`, // Large Charm
-  // cm3: `${RED}0 ${BLUE}Grand Charm ${RED}0${BLUE}`, // Grand Charm
-
+  customizeJunk() {
+    this.items.hp1 = `${RED}+${WHITE}HP1`;            // Minor Healing Potion
+    this.items.hp2 = `${RED}+${WHITE}HP2`;            // Light Healing Potion
+    this.items.hp3 = `${RED}+${WHITE}HP3`;            // Healing Potion
+    this.items.hp4 = `${RED}+${WHITE}HP4`;            // Greater Healing Potion
+    this.items.hp5 = `${RED}+${WHITE}HP5`;            // Super Healing Potion
+    
+    this.items.mp1 = `${BLUE}+${WHITE}MP1`;           // Minor Mana Potion
+    this.items.mp2 = `${BLUE}+${WHITE}MP2`;           // Light Mana Potion
+    this.items.mp3 = `${BLUE}+${WHITE}MP3`;           // Mana Potion
+    this.items.mp4 = `${BLUE}+${WHITE}MP4`;           // Greater Mana Potion
+    this.items.mp5 = `${BLUE}+${WHITE}MP5`;           // Super Mana Potion
+    
+    this.items.rvs = `${PURPLE}+${WHITE}RPS`;         // Rejuvenation Potion
+    this.items.rvl = `${PURPLE}+${WHITE}RPF`;         // Full Rejuvenation Potion
+    
+    this.items.yps = `${GREEN}+${WHITE}Antidote`;     // Antidote Potion
+    this.items.wms = `${GREEN}+${WHITE}Thawing`;      // Thawing Potion
+    this.items.vps = `${GREEN}+${WHITE}Stamina`;      // Stamina Potion
+    this.items.tbk = `${DARKGREEN1}+${WHITE}TP Tome`; // Tome of Town Portal
+    this.items.ibk = `${DARKGREEN1}+${WHITE}ID Tome`; // Tome of Identify
+    this.items.tsc = `${GREEN}+${WHITE}TP`;           // Scroll of Town Portal
+    this.items.isc = `${GREEN}+${WHITE}ID`;           // Scroll of Identify
+    
+    this.items.gpl = `${DARKGREEN1}o${WHITE} Gas 1`;  // Strangling Gas Potion
+    this.items.gpm = `${DARKGREEN1}o${WHITE} Gas 2`;  // Fulminating Potion
+    this.items.gps = `${DARKGREEN1}o${WHITE} Gas 3`;  // Choking Gas Potion
+    
+    this.items.opl = `${ORANGE}o${WHITE} Oil 1`;      // Exploding Potion
+    this.items.opm = `${ORANGE}o${WHITE} Oil 2`;      // Rancid Gas Potion
+    this.items.ops = `${ORANGE}o${WHITE} Oil 3`;      // Oil Potion
+    
+    this.items.aqv = `${GRAY}o${WHITE} Arrows`;       // Arrow Quiver
+    this.items.cqv = `${GRAY}o${WHITE} Bolts`;        // Crossbow Bolt Quiver
+    
+    // this.items.key = HIDDEN; // Regular key for locked chests
+  },
+    
   //==========//
   //   Gems   //
   //==========//
-  gcv: `${PURPLE}o${WHITE} Chipped`,  // Chipped Amethyst
-  gcw:  `${WHITE}o${WHITE} Chipped`,  // Chipped Diamond
-  gcg:  `${GREEN}o${WHITE} Chipped`,  // Chipped Emerald
-  gcr:    `${RED}o${WHITE} Chipped`,  // Chipped Ruby
-  gcb:   `${BLUE}o${WHITE} Chipped`,  // Chipped Sapphire
-  gcy: `${YELLOW}o${WHITE} Chipped`,  // Chipped Topaz
+  customizeGems() {
+    this.items.gcv = `${PURPLE}o${WHITE} Chipped`;  // Chipped Amethyst
+    this.items.gcw =  `${WHITE}o${WHITE} Chipped`;  // Chipped Diamond
+    this.items.gcg =  `${GREEN}o${WHITE} Chipped`;  // Chipped Emerald
+    this.items.gcr =    `${RED}o${WHITE} Chipped`;  // Chipped Ruby
+    this.items.gcb =   `${BLUE}o${WHITE} Chipped`;  // Chipped Sapphire
+    this.items.gcy = `${YELLOW}o${WHITE} Chipped`;  // Chipped Topaz
+    
+    this.items.gfv = `${PURPLE}o${WHITE} Flawed`;   // Flawed Amethyst
+    this.items.gfw =  `${WHITE}o${WHITE} Flawed`;   // Flawed Diamond
+    this.items.gfg =  `${GREEN}o${WHITE} Flawed`;   // Flawed Emerald
+    this.items.gfr =    `${RED}o${WHITE} Flawed`;   // Flawed Ruby
+    this.items.gfb =   `${BLUE}o${WHITE} Flawed`;   // Flawed Sapphire
+    this.items.gfy = `${YELLOW}o${WHITE} Flawed`;   // Flawed Topaz
+    
+    this.items.gsv = `${PURPLE}o${WHITE} Amethyst`; // Amethyst
+    // for diamond/emerald/ruby/sapphire; see customAffixes
+    this.items.gsy = `${YELLOW}o${WHITE} Topaz`;    // Topaz
+    
+    this.items.gzv = `${PURPLE}o${WHITE} Flawless`; // Flawless Amethyst
+    this.items.glw =  `${WHITE}o${WHITE} Flawless`; // Flawless Diamond
+    this.items.glg =  `${GREEN}o${WHITE} Flawless`; // Flawless Emerald
+    this.items.glr =    `${RED}o${WHITE} Flawless`; // Flawless Ruby
+    this.items.glb =   `${BLUE}o${WHITE} Flawless`; // Flawless Sapphire
+    this.items.gly = `${YELLOW}o${WHITE} Flawless`; // Flawless Topaz
+    
+    this.items.gpv = `${PURPLE}o${WHITE} Perfect`;  // Perfect Amethyst
+    this.items.gpw =  `${WHITE}o${WHITE} Perfect`;  // Perfect Diamond
+    this.items.gpg =  `${GREEN}o${WHITE} Perfect`;  // Perfect Emerald
+    this.items.gpr =    `${RED}o${WHITE} Perfect`;  // Perfect Ruby
+    this.items.gpb =   `${BLUE}o${WHITE} Perfect`;  // Perfect Sapphire
+    this.items.gpy = `${YELLOW}o${WHITE} Perfect`;  // Perfect Topaz
+    
+    this.items.skc = `${GRAY}o${WHITE} Chipped`;    // Chipped Skull
+    this.items.skf = `${GRAY}o${WHITE} Flawed`;     // Flawed Skull
+    this.items.sku = `${GRAY}o${WHITE} Skull`;      // Skull
+    this.items.skl = `${GRAY}o${WHITE} Flawless`;   // Flawless Skull
+    this.items.skz = `${GRAY}o${WHITE} Perfect`;    // Perfect Skull
+  },
 
-  gfv: `${PURPLE}o${WHITE} Flawed`,   // Flawed Amethyst
-  gfw:  `${WHITE}o${WHITE} Flawed`,   // Flawed Diamond
-  gfg:  `${GREEN}o${WHITE} Flawed`,   // Flawed Emerald
-  gfr:    `${RED}o${WHITE} Flawed`,   // Flawed Ruby
-  gfb:   `${BLUE}o${WHITE} Flawed`,   // Flawed Sapphire
-  gfy: `${YELLOW}o${WHITE} Flawed`,   // Flawed Topaz
+  //=============//
+  //   Jewelry   //   
+  //=============//
+  customizeJewelry() {
+    // BUGGED: crafted/rare/set/unique rings, amulets and jewels show up as blue
+    // this.items.amu = `${RED}0 ${BLUE}Amulet ${RED}0${BLUE}`; // Amulet
+    // this.items.rin = `${RED}0 ${BLUE}Ring ${RED}0${BLUE}`;   // Ring
+    // this.items.jew = `${RED}0 ${BLUE}Jewel ${RED}0${BLUE}`;  // Jewel
+    this.items["Rainbow Facet"] = `${RED}***** ${YELLOW}***** ${BLUE}***** ${GREEN}*****${GOLD}   Rainbow Facet   ${GREEN}***** ${BLUE}***** ${YELLOW}***** ${RED}*****${GOLD}`;
+  },
 
-  gsv: `${PURPLE}o${WHITE} Amethyst`, // Amethyst
-  // gsw:  `${WHITE}o${WHITE} Diamond`,  // Diamond    See Affixes ^ line 79
-  // gsg:  `${GREEN}o${WHITE} Emerald`,  // Emerald    See Affixes ^ line 80
-  // gsr:    `${RED}o${WHITE} Ruby`,     // Ruby       See Affixes ^ line 81
-  // gsb:   `${BLUE}o${WHITE} Sapphire`, // Sapphire   See Affixes ^ line 82
-  gsy: `${YELLOW}o${WHITE} Topaz`,    // Topaz
+  //============//
+  //   Charms   //   
+  //============//
+  customizeCharms() {
+    // charms
+    this.items.cm1 = `Small ${RED}Charm${BLUE}`; // Small Charm
+    this.items.cm2 = `Large ${RED}Charm${BLUE}`; // Large Charm
+    this.items.cm3 = `Grand ${RED}Charm${BLUE}`; // Grand Charm
 
-  gzv: `${PURPLE}o${WHITE} Flawless`, // Flawless Amethyst
-  glw:  `${WHITE}o${WHITE} Flawless`, // Flawless Diamond
-  glg:  `${GREEN}o${WHITE} Flawless`, // Flawless Emerald
-  glr:    `${RED}o${WHITE} Flawless`, // Flawless Ruby
-  glb:   `${BLUE}o${WHITE} Flawless`, // Flawless Sapphire
-  gly: `${YELLOW}o${WHITE} Flawless`, // Flawless Topaz
-  
-  gpv: `${PURPLE}o${WHITE} Perfect`,  // Perfect Amethyst
-  gpw:  `${WHITE}o${WHITE} Perfect`,  // Perfect Diamond
-  gpg:  `${GREEN}o${WHITE} Perfect`,  // Perfect Emerald
-  gpr:    `${RED}o${WHITE} Perfect`,  // Perfect Ruby
-  gpb:   `${BLUE}o${WHITE} Perfect`,  // Perfect Sapphire
-  gpy: `${YELLOW}o${WHITE} Perfect`,  // Perfect Topaz
-  
-  skc: `${GRAY}o${WHITE} Chipped`,    // Chipped Skull
-  skf: `${GRAY}o${WHITE} Flawed`,     // Flawed Skull
-  sku: `${GRAY}o${WHITE} Skull`,      // Skull
-  skl: `${GRAY}o${WHITE} Flawless`,   // Flawless Skull
-  skz: `${GRAY}o${WHITE} Perfect`,    // Perfect Skull
+    // unique charms
+    this.items["Annihilus"]       = `${RED}**********${GOLD}     Annihilus     ${RED}**********${GOLD}`;
+    this.items["Hellfire Torch"]  = `${RED}**********${GOLD}     Hellfire Torch     ${RED}**********${GOLD}`;
+    this.items["Gheed's Fortune"] = `${RED}**********${GOLD}     Gheed's Fortune     ${RED}**********${GOLD}`;
+    
+    // sunder charms
+    this.items["Black Cleft"]          = `${RED}**********${GOLD}     Black Cleft     ${RED}**********${GOLD}`;
+    this.items["Bone Break"]           = `${RED}**********${GOLD}     Bone Break     ${RED}**********${GOLD}`;
+    this.items["Cold Rupture"]         = `${RED}**********${GOLD}     Cold Rupture     ${RED}**********${GOLD}`;
+    this.items["Crack of the Heavens"] = `${RED}**********${GOLD}     Crack of the Heavens     ${RED}**********${GOLD}`;
+    this.items["Flame Rift"]           = `${RED}**********${GOLD}     Flame Rift     ${RED}**********${GOLD}`;
+    this.items["Rotting Fissure"]      = `${RED}**********${GOLD}     Rotting Fissure     ${RED}**********${GOLD}`;
+  },
 
-  //=======================//
-  //   Pandemonium Event   //
-  //=======================//
-  pk1: `${RED}*****${ORANGE}   Key of Terror   ${RED}*****${ORANGE}`,                  // Pandemonium Key 1 Key of Terror
-  pk2: `${RED}*****${ORANGE}   Key of Hate   ${RED}*****${ORANGE}`,                    // Pandemonium Key 2 Key of Hate
-  pk3: `${RED}*****${ORANGE}   Key of Destruction   ${RED}*****${ORANGE}`,             // Pandemonium Key 3 Key of Destruction
-  dhn: `${RED}**********${ORANGE}     Diablo's Horn     ${RED}**********${ORANGE}`,    // Diablo's Horn
-  bey: `${RED}**********${ORANGE}     Baal's Eye     ${RED}**********${ORANGE}`,       // Baal's Eye
-  mbr: `${RED}**********${ORANGE}     Mephisto's Brain     ${RED}**********${ORANGE}`, // Mephisto's Brain
-  std: `${RED}**${GOLD}  Standard of Heroes  ${RED}**${GOLD}`,                       // Standard of Heroes
-  
-  //======================//
-  //   Token & Essences   //
-  //======================//
-  tes: `${RED}**${ORANGE}  Twisted Essence of Suffering  ${RED}**${ORANGE}`,     // Twisted Essence of Suffering
-  ceh: `${RED}**${ORANGE}  Charged Essense of Hatred  ${RED}**${ORANGE}`,        // Charged Essense of Hatred
-  bet: `${RED}**${ORANGE}  Burning Essence of Terror  ${RED}**${ORANGE}`,        // Burning Essence of Terror
-  fed: `${RED}**${ORANGE}  Festering Essence of Destruction  ${RED}**${ORANGE}`, // Festering Essence of Destruction
-  toa: `${RED}*****${ORANGE}   Token of Absolution   ${RED}*****${ORANGE}`,          // Token of Absolution
+  customizeEndgame() {
+    //=======================//
+    //   Pandemonium Event   //
+    //=======================//
+    this.items.pk1 = `${RED}**********${ORANGE}     Key of Terror     ${RED}**********${ORANGE}`;                  // Pandemonium Key 1 Key of Terror
+    this.items.pk2 = `${RED}**********${ORANGE}     Key of Hate     ${RED}**********${ORANGE}`;                    // Pandemonium Key 2 Key of Hate
+    this.items.pk3 = `${RED}**********${ORANGE}     Key of Destruction     ${RED}**********${ORANGE}`;             // Pandemonium Key 3 Key of Destruction
+    this.items.dhn = `${RED}**********${ORANGE}     Diablo's Horn     ${RED}**********${ORANGE}`;    // Diablo's Horn
+    this.items.bey = `${RED}**********${ORANGE}     Baal's Eye     ${RED}**********${ORANGE}`;       // Baal's Eye
+    this.items.mbr = `${RED}**********${ORANGE}     Mephisto's Brain     ${RED}**********${ORANGE}`; // Mephisto's Brain
+    this.items.std = `${RED}*****${GOLD}   Standard of Heroes   ${RED}*****${GOLD}`;                       // Standard of Heroes
+    
+    //======================//
+    //   Token & Essences   //
+    //======================//
+    this.items.tes = `${RED}*****${ORANGE}   Twisted Essence of Suffering   ${RED}*****${ORANGE}`;     // Twisted Essence of Suffering
+    this.items.ceh = `${RED}*****${ORANGE}   Charged Essense of Hatred   ${RED}*****${ORANGE}`;        // Charged Essense of Hatred
+    this.items.bet = `${RED}*****${ORANGE}   Burning Essence of Terror   ${RED}*****${ORANGE}`;        // Burning Essence of Terror
+    this.items.fed = `${RED}*****${ORANGE}   Festering Essence of Destruction   ${RED}*****${ORANGE}`; // Festering Essence of Destruction
+    this.items.toa = `${RED}*****${ORANGE}   Token of Absolution   ${RED}*****${ORANGE}`;          // Token of Absolution
+  },
 
   //=================//
   //   Quest Items   //
   //=================//
-  // Act 1
-  leg: `${RED}**********${GOLD}     Wirt's Leg     ${RED}**********${GOLD}`,           // Wirt's Leg
-  hdm: `${RED}**********${GOLD}     Horadric Malus     ${RED}**********${GOLD}`,       // Horadric Malus
-  bks: `${RED}**********${GOLD}     Scroll of Inifuss     ${RED}**********${GOLD}`,    // Scroll of Inifuss
-  bkd: `${RED}**********${GOLD}     Scroll of Inifuss     ${RED}**********${GOLD}`,    // Scroll of Inifuss (deciphered)
-  // Act 2
-  ass: `${RED}**********${GOLD}     Book of Skill     ${RED}**********${GOLD}`,        // Book of Skill
-  box: `${RED}**********${GOLD}     Horadric Cube     ${RED}**********${GOLD}`,        // Horadric Cube
-  tr1: `${RED}**********${GOLD}     Horadric Scroll     ${RED}**********${GOLD}`,      // Horadric Scroll
-  msf: `${RED}**********${GOLD}     Staff of Kings     ${RED}**********${GOLD}`,       // Staff of Kings
-  vip: `${RED}**********${GOLD}     Amulet of the Viper     ${RED}**********${GOLD}`,  // Amulet of the Viper
-  hst: `${RED}**********${GOLD}     Horadric Staff     ${RED}**********${GOLD}`,       // Horadric Staff
-  // Act 3
-  xyz: `${RED}**********${GOLD}     Potion of Life     ${RED}**********${GOLD}`,       // Potion of Life
-  j34: `${RED}**********${GOLD}     A Jade Figurine     ${RED}**********${GOLD}`,      // A Jade Figurine
-  g34: `${RED}**********${GOLD}     The Golden Bird     ${RED}**********${GOLD}`,      // The Golden Bird
-  bbb: `${RED}**********${GOLD}     Lam Esen's Tome     ${RED}**********${GOLD}`,      // Lam Esen's Tome
-  g33: `${RED}**********${GOLD}     The Gidbinn     ${RED}**********${GOLD}`,          // The Gidbinn
-  qf1: `${RED}**********${GOLD}     Khalim's Flail     ${RED}**********${GOLD}`,       // Khalim's Flail
-  qf2: `${RED}**********${GOLD}     Khalim's Will     ${RED}**********${GOLD}`,        // Khalim's Will
-  qey: `${RED}**********${GOLD}     Khalim's Eye     ${RED}**********${GOLD}`,         // Khalim's Eye
-  qhr: `${RED}**********${GOLD}     Khalim's Heart     ${RED}**********${GOLD}`,       // Khalim's Heart
-  qbr: `${RED}**********${GOLD}     Khalim's Brain     ${RED}**********${GOLD}`,       // Khalim's Brain
-  mss: `${RED}**********${GOLD}     Mephisto's Soulstone     ${RED}**********${GOLD}`, // Mephisto's Soulstone
-  // Act 4
-  hfh: `${RED}**********${GOLD}     Hellforge Hammer     ${RED}**********${GOLD}`,     // Hellforge Hammer
-  // Act 5
-  ice: `${RED}**********${GOLD}     Malah's Potion     ${RED}**********${GOLD}`,       // Malah's Potion
-  tr2: `${RED}**********${GOLD}     Scroll of Resistance     ${RED}**********${GOLD}`, // Scroll of Resistance
+  customizeQuest() {
+    // Act 1
+    this.items.leg = `${RED}**********${GOLD}     Wirt's Leg     ${RED}**********${GOLD}`;           // Wirt's Leg
+    this.items.hdm = `${RED}**********${GOLD}     Horadric Malus     ${RED}**********${GOLD}`;       // Horadric Malus
+    this.items.bks = `${RED}**********${GOLD}     Scroll of Inifuss     ${RED}**********${GOLD}`;    // Scroll of Inifuss
+    this.items.bkd = `${RED}**********${GOLD}     Scroll of Inifuss     ${RED}**********${GOLD}`;    // Scroll of Inifuss (deciphered)
+    // Act 2
+    this.items.tr1 = `${RED}**********${GOLD}     Horadric Scroll     ${RED}**********${GOLD}`;      // Horadric Scroll
+    this.items.msf = `${RED}**********${GOLD}     Staff of Kings     ${RED}**********${GOLD}`;       // Staff of Kings
+    this.items.vip = `${RED}**********${GOLD}     Amulet of the Viper     ${RED}**********${GOLD}`;  // Amulet of the Viper
+    this.items.hst = `${RED}**********${GOLD}     Horadric Staff     ${RED}**********${GOLD}`;       // Horadric Staff
+    // Act 3
+    this.items.j34 = `${RED}**********${GOLD}     A Jade Figurine     ${RED}**********${GOLD}`;      // A Jade Figurine
+    this.items.g34 = `${RED}**********${GOLD}     The Golden Bird     ${RED}**********${GOLD}`;      // The Golden Bird
+    this.items.bbb = `${RED}**********${GOLD}     Lam Esen's Tome     ${RED}**********${GOLD}`;      // Lam Esen's Tome
+    this.items.g33 = `${RED}**********${GOLD}     The Gidbinn     ${RED}**********${GOLD}`;          // The Gidbinn
+    this.items.qf1 = `${RED}**********${GOLD}     Khalim's Flail     ${RED}**********${GOLD}`;       // Khalim's Flail
+    this.items.qf2 = `${RED}**********${GOLD}     Khalim's Will     ${RED}**********${GOLD}`;        // Khalim's Will
+    this.items.qey = `${RED}**********${GOLD}     Khalim's Eye     ${RED}**********${GOLD}`;         // Khalim's Eye
+    this.items.qhr = `${RED}**********${GOLD}     Khalim's Heart     ${RED}**********${GOLD}`;       // Khalim's Heart
+    this.items.qbr = `${RED}**********${GOLD}     Khalim's Brain     ${RED}**********${GOLD}`;       // Khalim's Brain
+    this.items.mss = `${RED}**********${GOLD}     Mephisto's Soulstone     ${RED}**********${GOLD}`; // Mephisto's Soulstone
+    // Act 4
+    this.items.hfh = `${RED}**********${GOLD}     Hell Forge Hammer     ${RED}**********${GOLD}`;     // Hell Forge Hammer
+    // Act 5
+    
+    // Extra
+    this.items["Staff of Kings"] =      `${RED}**********${GOLD}     Staff of Kings     ${RED}**********${GOLD}`;      // Staff of Kings
+    this.items["Amulet of the Viper"] = `${RED}**********${GOLD}     Amulet of the Viper     ${RED}**********${GOLD}`; // Amulet of the Viper
+    this.items["Horadric Staff"] =      `${RED}**********${GOLD}     Horadric Staff     ${RED}**********${GOLD}`;      // Horadric Staff
+    this.items.LamTome =                `${RED}**********${GOLD}     Lam Esen's Tome     ${RED}**********${GOLD}`;     // Lam Esen's Tome
+    this.items.KhalimFlail =            `${RED}**********${GOLD}     Khalim's Flail     ${RED}**********${GOLD}`;      // Khalim's Flail
+    this.items.SuperKhalimFlail =       `${RED}**********${GOLD}     Khalim's Will     ${RED}**********${GOLD}`;       // Khalim's Will
+    this.items["Hell Forge Hammer"] =   `${RED}**********${GOLD}     Hell Forge Hammer     ${RED}**********${GOLD}`;   // Hell Forge Hammer
+  },
 
-  // Extra
-  LamTome:          `${RED}**********${GOLD}     Lam Esen's Tome     ${RED}**********${GOLD}`, // Lam Esen's Tome
-  KhalimFlail:      `${RED}**********${GOLD}     Khalim's Flail     ${RED}**********${GOLD}`,  // Khalim's Flail
-  SuperKhalimFlail: `${RED}**********${GOLD}     Khalim's Will     ${RED}**********${GOLD}`,   // Khalim's Will
+  customizeCube() {
+    this.items.box = `${RED}**********${GOLD}     Horadric Cube     ${RED}**********${GOLD}`;
+  }
 };
-
-customItems["Staff of Kings"]      = `${RED}**********${GOLD}     Staff of Kings     ${RED}**********${GOLD}`;      // Staff of Kings
-customItems["Amulet of the Viper"] = `${RED}**********${GOLD}     Amulet of the Viper     ${RED}**********${GOLD}`; // Amulet of the Viper
-customItems["Horadric Staff"]      = `${RED}**********${GOLD}     Horadric Staff     ${RED}**********${GOLD}`;      // Horadric Staff
-customItems["Hell Forge Hammer"]   = `${RED}**********${GOLD}     Hell Forge Hammer     ${RED}**********${GOLD}`;   // Hellforge Hammer
-
 
 //===============//
 //   Custom UI   //
 //===============//
 const customUi = {
+  items: {},
 
-  //=================//
-  //   Quest Items   //
-  //=================//
-  // For some reason, the devs put these gems in the wrong JSON file.
-  ass: `${RED}**********${GOLD}     Book of Skill     ${RED}**********${GOLD}`,  // Book of Skill
-  xyz: `${RED}**********${GOLD}     Potion of Life     ${RED}**********${GOLD}`, // Potion of Life
+  customizeQuest() {
+    // For some reason the devs put these quest items in the wrong JSON file.
+    this.items.ass = `${RED}**********${GOLD}     Book of Skill     ${RED}**********${GOLD}`;  // Book of Skill
+    this.items.xyz = `${RED}**********${GOLD}     Potion of Life     ${RED}**********${GOLD}`; // Potion of Life
+  }
+};
+
+//======================//
+//   Custom Modifiers   //
+//======================//
+const customModifiers = {
+  items: {},
+  
+  customizeQuest() {
+    // For some reason the devs put these quest items in the wrong JSON file.
+    this.items.ice = `${RED}**********${GOLD}     Malah's Potion     ${RED}**********${GOLD}`;       // Malah's Potion
+    this.items.tr2 = `${RED}**********${GOLD}     Scroll of Resistance     ${RED}**********${GOLD}`; // Scroll of Resistance
+  }
 };
 
 
-function applyLootFilter() {
-  applyItemNameMods();
-  applyTooltipMods();
+//============================//
+//   How to apply the magic   //
+//============================//
+
+// Gold, Superior/Inferior affixes, Gems (exceptions)
+function applyCustomAffixes() {
+  if (!config.IsGoldEnabled && !config.IsGemsEnabled && !config.ShortSupInf) {
+    return;
+  }
+  
+  if (config.IsGoldEnabled) {
+    customAffixes.customizeGold();
+  }
+  if (config.IsGemsEnabled) {
+    customAffixes.customizeGems();
+  }
+  if (config.ShortSupInf) {
+    customAffixes.customizeSupInf();
+  }
+
+  applyCustomNames(FILE_ITEM_NAMEAFFIXES_PATH, customAffixes.items);
 }
 
-function applyItemNameMods() {
-  if (config.IsGoldEnabled) {
-    applyCustomNames(itemNameAffixesPath, customAffixes);
-  }
+// Runes
+function applyCustomRuneNames() {
   if (config.IsRunesEnabled) {
-    applyCustomNames(itemRunesPath, customRunes);
+    applyCustomNames(FILE_ITEM_RUNES_PATH, customRunes);
   }
-  if (config.IsItemsEnabled) {
-    applyCustomNames(itemNamesPath, customItems);
-    applyCustomNames(uiPath, customUi);
+}
+
+function applyCustomItemNames() {
+  if (!config.IsJunkEnabled && !config.IsGemsEnabled && !config.IsJewelryEnabled && !config.IsCharmsEnabled && !config.IsQuestEnabled && !config.IsEndgameEnabled) {
+    return;
   }
+
+  if (config.IsJunkEnabled) {
+    customItemNames.customizeJunk();
+  }
+  if (config.IsGemsEnabled) {
+    customItemNames.customizeGems();
+  }
+  if (config.IsJewelryEnabled) {
+    customItemNames.customizeJewelry();
+  }
+  if (config.IsCharmsEnabled) {
+    customItemNames.customizeCharms();
+  }
+  if (config.IsQuestEnabled) {
+    customItemNames.customizeQuest();
+    if (!config.ShouldExcludeCube) {
+      customizeCube();
+    }
+  }
+  if (config.IsEndgameEnabled) {
+    customItemNames.customizeEndgame();
+  }
+
+  applyCustomNames(FILE_ITEM_NAMES_PATH, customItemNames.items);
+}
+
+// quest
+function applyCustomUi() {
+  if (!config.IsQuestEnabled) {
+    return;
+  }
+  customUi.customizeQuest();
+  applyCustomNames(FILE_ITEM_UI_PATH, customUi.items);
+}
+
+// quest
+function applyCustomModifiers() {
+  if (!config.IsQuestEnabled) {
+    return;
+  }
+  customModifiers.customizeQuest();
+  applyCustomNames(FILE_ITEM_MODIFIERS_PATH, customModifiers.items);
 }
 
 function applyCustomNames(path, customNames) {
@@ -341,7 +452,7 @@ function applyTooltipMods() {
   if (config.Tooltip == "none")
     return
 
-  let profileHD = D2RMM.readJson(profileHdPath);
+  let profileHD = D2RMM.readJson(FILE_PROFILE_HD_PATH);
 
   switch (config.Tooltip) {
     case "all":
@@ -356,11 +467,21 @@ function applyTooltipMods() {
       break;
   }
   
-  D2RMM.writeJson(profileHdPath, profileHD);
-  D2RMM.copyFile('hd', 'hd', true);
-  // This simply copies the rune.json files instead of modifying each one with code which 
-  // I am too dumb to understand how to do. It gets the job done, it may cause issues if 
-  // you have other mods that modify the runes.json files.
+  D2RMM.writeJson(FILE_PROFILE_HD_PATH, profileHD);
+}
+
+
+//========================//
+//   Applying the magic   //
+//========================//
+
+function applyLootFilter() {
+  applyCustomAffixes();
+  applyCustomRuneNames();
+  applyCustomItemNames();
+  applyCustomUi();
+  applyCustomModifiers();
+  applyTooltipMods();
 }
 
 applyLootFilter();

--- a/CaedendiSimpleLootFilter/mod.js
+++ b/CaedendiSimpleLootFilter/mod.js
@@ -12,9 +12,11 @@
 
 // File paths
 const profileHdPath = 'global\\ui\\layouts\\_profilehd.json';
-const itemRunesPath = 'local\\lng\\strings\\item-runes.json';
-const itemNamesPath = 'local\\lng\\strings\\item-names.json';
+
 const itemNameAffixesPath = 'local\\lng\\strings\\item-nameaffixes.json';
+const itemNamesPath = 'local\\lng\\strings\\item-names.json';
+const itemRunesPath = 'local\\lng\\strings\\item-runes.json';
+const uiPath = 'local\\lng\\strings\\ui.json';
 
 // Color
 const COLOR_PREFIX = 'ÿc';
@@ -64,13 +66,20 @@ const HIDDEN = '' + ' '.repeat(config.HiddenItemTooltipSize);
 //   Affixes   //
 //=============//
 const customAffixes = {
+
+  //==========//
+  //   Gold   //
+  //==========//
   gld: `${GOLD1}G`, // Gold displays as "1234 G" with white numbers and gold-colored G.
 
+  //==========//
+  //   Gems   //
+  //==========//
   // For some reason, the devs put these gems in the wrong JSON file.
-  gsw:  `${WHITE}o ${WHITE}Diamond`,  // Diamond
-  gsg:  `${GREEN}o ${WHITE}Emerald`,  // Emerald
-  gsr:    `${RED}o ${WHITE}Ruby`,     // Ruby
-  gsb:   `${BLUE}o ${WHITE}Sapphire`, // Sapphire
+  gsw: `${WHITE}o ${WHITE}Diamond`,  // Diamond
+  gsg: `${GREEN}o ${WHITE}Emerald`,  // Emerald
+  gsr:   `${RED}o ${WHITE}Ruby`,     // Ruby
+  gsb:  `${BLUE}o ${WHITE}Sapphire`, // Sapphire
 };
 
 
@@ -78,39 +87,39 @@ const customAffixes = {
 //   Runes   //
 //===========//
 const customRunes = {
-  /*El   */ r01: `${ORANGE1}El (1)`,
-  /*Eld  */ r02: `${ORANGE1}Eld (2)`,
-  /*Tir  */ r03: `${ORANGE1}Tir (3)`,
-  /*Nef  */ r04: `${ORANGE1}Nef (4)`,
-  /*Eth  */ r05: `${ORANGE1}Eth (5)`,
-  /*Ith  */ r06: `${ORANGE1}Ith (6)`,
-  /*Tal  */ r07: `${ORANGE1}Tal (7)`,
-  /*Ral  */ r08: `${RED}**  ${ORANGE1}Ral (8)  ${RED}**`,
-  /*Ort  */ r09: `${ORANGE1}Ort (9)`,
-  /*Thul */ r10: `${ORANGE1}Thul (10)`,
-  /*Amn  */ r11: `${ORANGE1}Amn (11)`,
-  /*Sol  */ r12: `${ORANGE1}Sol (12)`,
-  /*Shael*/ r13: `${ORANGE1}Shael (13)`,
-  /*Dol  */ r14: `${ORANGE1}Dol (14)`,
-  /*Hel  */ r15: `${RED}**  ${ORANGE1}Hel (15) ${RED}*`,
-  /*Io   */ r16: `${ORANGE1}Io (16)`,
-  /*Lum  */ r17: `${ORANGE1}Lum (17)`,
-  /*Ko   */ r18: `${RED}**  ${ORANGE1}Ko (18)  ${RED}**`,
-  /*Fal  */ r19: `${RED}**  ${ORANGE1}Fal (19)  ${RED}**`,
-  /*Lem  */ r20: `${RED}**  ${ORANGE1}Lem (20)  ${RED}**`,
-  /*Pul  */ r21: `${RED}*****   ${ORANGE1}Pul (21)   ${RED}*****`,
-  /*Um   */ r22: `${RED}*****   ${ORANGE1}Um (22)   ${RED}*****`,
-  /*Mal  */ r23: `${RED}*****   ${ORANGE1}Mal (23)   ${RED}*****`,
-  /*Ist  */ r24: `${RED}*****   ${ORANGE1}Ist (24)   ${RED}*****`,
-  /*Gul  */ r25: `${RED}*****   ${ORANGE1}Gul (25)   ${RED}*****`,
-  /*Vex  */ r26: `${RED}**********     ${ORANGE1}Vex (26)     ${RED}**********`,
-  /*Ohm  */ r27: `${RED}**********     ${ORANGE1}Ohm (27)     ${RED}**********`,
-  /*Lo   */ r28: `${RED}**********     ${ORANGE1}Lo (28)     ${RED}**********`,
-  /*Sur  */ r29: `${RED}**********     ${ORANGE1}Sur (29)     ${RED}**********`,
-  /*Ber  */ r30: `${RED}**********     ${ORANGE1}Ber (30)     ${RED}**********`,
-  /*Jah  */ r31: `${RED}**********     ${ORANGE1}Jah (31)     ${RED}**********`,
-  /*Cham */ r32: `${RED}**********     ${ORANGE1}Cham (32)     ${RED}**********`,
-  /*Zod  */ r33: `${RED}**********     ${ORANGE1}Zod (33)     ${RED}**********`,
+  /* El    */ r01: `${ORANGE1}El (1)`,
+  /* Eld   */ r02: `${ORANGE1}Eld (2)`,
+  /* Tir   */ r03: `${ORANGE1}Tir (3)`,
+  /* Nef   */ r04: `${ORANGE1}Nef (4)`,
+  /* Eth   */ r05: `${ORANGE1}Eth (5)`,
+  /* Ith   */ r06: `${ORANGE1}Ith (6)`,
+  /* Tal   */ r07: `${ORANGE1}Tal (7)`,
+  /* Ral   */ r08: `${RED}**${ORANGE1}  Ral (8)  ${RED}**${ORANGE1}`,
+  /* Ort   */ r09: `${ORANGE1}Ort (9)`,
+  /* Thul  */ r10: `${ORANGE1}Thul (10)`,
+  /* Amn   */ r11: `${ORANGE1}Amn (11)`,
+  /* Sol   */ r12: `${ORANGE1}Sol (12)`,
+  /* Shael */ r13: `${ORANGE1}Shael (13)`,
+  /* Dol   */ r14: `${ORANGE1}Dol (14)`,
+  /* Hel   */ r15: `${RED}**${ORANGE1}  Hel (15) ${RED}**${ORANGE1}`,
+  /* Io    */ r16: `${ORANGE1}Io (16)`,
+  /* Lum   */ r17: `${ORANGE1}Lum (17)`,
+  /* Ko    */ r18: `${RED}**${ORANGE1}  Ko (18)  ${RED}**${ORANGE1}`,
+  /* Fal   */ r19: `${RED}**${ORANGE1}  Fal (19)  ${RED}**${ORANGE1}`,
+  /* Lem   */ r20: `${RED}**${ORANGE1}  Lem (20)  ${RED}**${ORANGE1}`,
+  /* Pul   */ r21: `${RED}*****${ORANGE1}   Pul (21)   ${RED}*****${ORANGE1}`,
+  /* Um    */ r22: `${RED}*****${ORANGE1}   Um (22)   ${RED}*****${ORANGE1}`,
+  /* Mal   */ r23: `${RED}*****${ORANGE1}   Mal (23)   ${RED}*****${ORANGE1}`,
+  /* Ist   */ r24: `${RED}*****${ORANGE1}   Ist (24)   ${RED}*****${ORANGE1}`,
+  /* Gul   */ r25: `${RED}*****${ORANGE1}   Gul (25)   ${RED}*****${ORANGE1}`,
+  /* Vex   */ r26: `${RED}**********${ORANGE1}     Vex (26)     ${RED}**********${ORANGE1}`,
+  /* Ohm   */ r27: `${RED}**********${ORANGE1}     Ohm (27)     ${RED}**********${ORANGE1}`,
+  /* Lo    */ r28: `${RED}**********${ORANGE1}     Lo (28)     ${RED}**********${ORANGE1}`,
+  /* Sur   */ r29: `${RED}**********${ORANGE1}     Sur (29)     ${RED}**********${ORANGE1}`,
+  /* Ber   */ r30: `${RED}**********${ORANGE1}     Ber (30)     ${RED}**********${ORANGE1}`,
+  /* Jah   */ r31: `${RED}**********${ORANGE1}     Jah (31)     ${RED}**********${ORANGE1}`,
+  /* Cham  */ r32: `${RED}**********${ORANGE1}     Cham (32)     ${RED}**********${ORANGE1}`,
+  /* Zod   */ r33: `${RED}**********${ORANGE1}     Zod (33)     ${RED}**********${ORANGE1}`,
 };
 
 
@@ -134,8 +143,8 @@ const customItems = {
   mp4: `${BLUE}+${WHITE}MP4`, // Greater Mana Potion
   mp5: `${BLUE}+${WHITE}MP5`, // Super Mana Potion
   
-  rvs: `${PURPLE}+${WHITE}SRP`, // Rejuvenation Potion
-  rvl: `${PURPLE}+${WHITE}FRP`, // Full Rejuvenation Potion
+  rvs: `${PURPLE}+${WHITE}RPS`, // Rejuvenation Potion
+  rvl: `${PURPLE}+${WHITE}RPF`, // Full Rejuvenation Potion
   
   yps: `${GREEN}+${WHITE}Antidote`, // Antidote Potion
   wms: `${GREEN}+${WHITE}Thawing`, // Thawing Potion
@@ -149,16 +158,16 @@ const customItems = {
   tsc: `${GREEN}+${WHITE}TP`,      // Scroll of Town Portal
   isc: `${GREEN}+${WHITE}ID`,      // Scroll of Identify
 
-  gpl: `${DARKGREEN1}o ${WHITE}Gas 1`, // Strangling Gas Potion
-  gpm: `${DARKGREEN1}o ${WHITE}Gas 2`, // Fulminating Potion
-  gps: `${DARKGREEN1}o ${WHITE}Gas 3`, // Choking Gas Potion
+  gpl: `${DARKGREEN1}o${WHITE} Gas 1`, // Strangling Gas Potion
+  gpm: `${DARKGREEN1}o${WHITE} Gas 2`, // Fulminating Potion
+  gps: `${DARKGREEN1}o${WHITE} Gas 3`, // Choking Gas Potion
 
-  opl: `${ORANGE}o ${WHITE}Oil 1`, // Exploding Potion
-  opm: `${ORANGE}o ${WHITE}Oil 2`, // Rancid Gas Potion
-  ops: `${ORANGE}o ${WHITE}Oil 3`, // Oil Potion
+  opl: `${ORANGE}o${WHITE} Oil 1`, // Exploding Potion
+  opm: `${ORANGE}o${WHITE} Oil 2`, // Rancid Gas Potion
+  ops: `${ORANGE}o${WHITE} Oil 3`, // Oil Potion
 
-  aqv: `${GRAY}o ${WHITE}Arrows`, // Arrow Quiver
-  cqv: `${GRAY}o ${WHITE}Bolts`, // Crossbow Bolt Quiver
+  aqv: `${GRAY}o${WHITE} Arrows`, // Arrow Quiver
+  cqv: `${GRAY}o${WHITE} Bolts`, // Crossbow Bolt Quiver
 
   // key: HIDDEN, // Regular key for locked chests
 
@@ -176,99 +185,123 @@ const customItems = {
   //==========//
   //   Gems   //
   //==========//
-  gcv: `${PURPLE}o ${WHITE}Chipped`,  // Chipped Amethyst
-  gcw:  `${WHITE}o ${WHITE}Chipped`,  // Chipped Diamond
-  gcg:  `${GREEN}o ${WHITE}Chipped`,  // Chipped Emerald
-  gcr:    `${RED}o ${WHITE}Chipped`,  // Chipped Ruby
-  gcb:   `${BLUE}o ${WHITE}Chipped`,  // Chipped Sapphire
-  gcy: `${YELLOW}o ${WHITE}Chipped`,  // Chipped Topaz
+  gcv: `${PURPLE}o${WHITE} Chipped`,  // Chipped Amethyst
+  gcw:  `${WHITE}o${WHITE} Chipped`,  // Chipped Diamond
+  gcg:  `${GREEN}o${WHITE} Chipped`,  // Chipped Emerald
+  gcr:    `${RED}o${WHITE} Chipped`,  // Chipped Ruby
+  gcb:   `${BLUE}o${WHITE} Chipped`,  // Chipped Sapphire
+  gcy: `${YELLOW}o${WHITE} Chipped`,  // Chipped Topaz
 
-  gfv: `${PURPLE}o ${WHITE}Flawed`,   // Flawed Amethyst
-  gfw:  `${WHITE}o ${WHITE}Flawed`,   // Flawed Diamond
-  gfg:  `${GREEN}o ${WHITE}Flawed`,   // Flawed Emerald
-  gfr:    `${RED}o ${WHITE}Flawed`,   // Flawed Ruby
-  gfb:   `${BLUE}o ${WHITE}Flawed`,   // Flawed Sapphire
-  gfy: `${YELLOW}o ${WHITE}Flawed`,   // Flawed Topaz
+  gfv: `${PURPLE}o${WHITE} Flawed`,   // Flawed Amethyst
+  gfw:  `${WHITE}o${WHITE} Flawed`,   // Flawed Diamond
+  gfg:  `${GREEN}o${WHITE} Flawed`,   // Flawed Emerald
+  gfr:    `${RED}o${WHITE} Flawed`,   // Flawed Ruby
+  gfb:   `${BLUE}o${WHITE} Flawed`,   // Flawed Sapphire
+  gfy: `${YELLOW}o${WHITE} Flawed`,   // Flawed Topaz
 
-  gsv: `${PURPLE}o ${WHITE}Amethyst`, // Amethyst
-  // gsw:  `${WHITE}o ${WHITE}Diamond`,  // Diamond    See Affixes ^ line 70
-  // gsg:  `${GREEN}o ${WHITE}Emerald`,  // Emerald    See Affixes ^ line 71
-  // gsr:    `${RED}o ${WHITE}Ruby`,     // Ruby       See Affixes ^ line 72
-  // gsb:   `${BLUE}o ${WHITE}Sapphire`, // Sapphire   See Affixes ^ line 73
-  gsy: `${YELLOW}o ${WHITE}Topaz`,    // Topaz
+  gsv: `${PURPLE}o${WHITE} Amethyst`, // Amethyst
+  // gsw:  `${WHITE}o${WHITE} Diamond`,  // Diamond    See Affixes ^ line 79
+  // gsg:  `${GREEN}o${WHITE} Emerald`,  // Emerald    See Affixes ^ line 80
+  // gsr:    `${RED}o${WHITE} Ruby`,     // Ruby       See Affixes ^ line 81
+  // gsb:   `${BLUE}o${WHITE} Sapphire`, // Sapphire   See Affixes ^ line 82
+  gsy: `${YELLOW}o${WHITE} Topaz`,    // Topaz
 
-  gzv: `${PURPLE}o ${WHITE}Flawless`, // Flawless Amethyst
-  glw:  `${WHITE}o ${WHITE}Flawless`, // Flawless Diamond
-  glg:  `${GREEN}o ${WHITE}Flawless`, // Flawless Emerald
-  glr:    `${RED}o ${WHITE}Flawless`, // Flawless Ruby
-  glb:   `${BLUE}o ${WHITE}Flawless`, // Flawless Sapphire
-  gly: `${YELLOW}o ${WHITE}Flawless`, // Flawless Topaz
+  gzv: `${PURPLE}o${WHITE} Flawless`, // Flawless Amethyst
+  glw:  `${WHITE}o${WHITE} Flawless`, // Flawless Diamond
+  glg:  `${GREEN}o${WHITE} Flawless`, // Flawless Emerald
+  glr:    `${RED}o${WHITE} Flawless`, // Flawless Ruby
+  glb:   `${BLUE}o${WHITE} Flawless`, // Flawless Sapphire
+  gly: `${YELLOW}o${WHITE} Flawless`, // Flawless Topaz
   
-  gpv: `${PURPLE}o ${WHITE}Perfect`,  // Perfect Amethyst
-  gpw:  `${WHITE}o ${WHITE}Perfect`,  // Perfect Diamond
-  gpg:  `${GREEN}o ${WHITE}Perfect`,  // Perfect Emerald
-  gpr:    `${RED}o ${WHITE}Perfect`,  // Perfect Ruby
-  gpb:   `${BLUE}o ${WHITE}Perfect`,  // Perfect Sapphire
-  gpy: `${YELLOW}o ${WHITE}Perfect`,  // Perfect Topaz
+  gpv: `${PURPLE}o${WHITE} Perfect`,  // Perfect Amethyst
+  gpw:  `${WHITE}o${WHITE} Perfect`,  // Perfect Diamond
+  gpg:  `${GREEN}o${WHITE} Perfect`,  // Perfect Emerald
+  gpr:    `${RED}o${WHITE} Perfect`,  // Perfect Ruby
+  gpb:   `${BLUE}o${WHITE} Perfect`,  // Perfect Sapphire
+  gpy: `${YELLOW}o${WHITE} Perfect`,  // Perfect Topaz
   
-  skc: `${GRAY}o ${WHITE}Chipped`,    // Chipped Skull
-  skf: `${GRAY}o ${WHITE}Flawed`,     // Flawed Skull
-  sku: `${GRAY}o ${WHITE}Skull`,      // Skull
-  skl: `${GRAY}o ${WHITE}Flawless`,   // Flawless Skull
-  skz: `${GRAY}o ${WHITE}Perfect`,    // Perfect Skull
+  skc: `${GRAY}o${WHITE} Chipped`,    // Chipped Skull
+  skf: `${GRAY}o${WHITE} Flawed`,     // Flawed Skull
+  sku: `${GRAY}o${WHITE} Skull`,      // Skull
+  skl: `${GRAY}o${WHITE} Flawless`,   // Flawless Skull
+  skz: `${GRAY}o${WHITE} Perfect`,    // Perfect Skull
 
   //=======================//
   //   Pandemonium Event   //
   //=======================//
-  pk1: `${RED}*****   ${ORANGE}Key of Terror   ${RED}*****`,                  // Pandemonium Key 1 Key of Terror
-  pk2: `${RED}*****   ${ORANGE}Key of Hate   ${RED}*****`,                    // Pandemonium Key 2 Key of Hate
-  pk3: `${RED}*****   ${ORANGE}Key of Destruction   ${RED}*****`,             // Pandemonium Key 3 Key of Destruction
-  dhn: `${RED}**********     ${ORANGE}Diablo's Horn     ${RED}**********`,    // Diablo's Horn
-  bey: `${RED}**********     ${ORANGE}Baal's Eye     ${RED}**********`,       // Baal's Eye
-  mbr: `${RED}**********     ${ORANGE}Mephisto's Brain     ${RED}**********`, // Mephisto's Brain
-  std: `${RED}**  ${GOLD}Standard of Heroes  ${RED}**`,                       // Standard of Heroes
+  pk1: `${RED}*****${ORANGE}   Key of Terror   ${RED}*****${ORANGE}`,                  // Pandemonium Key 1 Key of Terror
+  pk2: `${RED}*****${ORANGE}   Key of Hate   ${RED}*****${ORANGE}`,                    // Pandemonium Key 2 Key of Hate
+  pk3: `${RED}*****${ORANGE}   Key of Destruction   ${RED}*****${ORANGE}`,             // Pandemonium Key 3 Key of Destruction
+  dhn: `${RED}**********${ORANGE}     Diablo's Horn     ${RED}**********${ORANGE}`,    // Diablo's Horn
+  bey: `${RED}**********${ORANGE}     Baal's Eye     ${RED}**********${ORANGE}`,       // Baal's Eye
+  mbr: `${RED}**********${ORANGE}     Mephisto's Brain     ${RED}**********${ORANGE}`, // Mephisto's Brain
+  std: `${RED}**${GOLD}  Standard of Heroes  ${RED}**${GOLD}`,                       // Standard of Heroes
   
   //======================//
   //   Token & Essences   //
   //======================//
-  tes: `${RED}**  ${ORANGE}Twisted Essence of Suffering  ${RED}**`,     // Twisted Essence of Suffering
-  ceh: `${RED}**  ${ORANGE}Charged Essense of Hatred  ${RED}**`,        // Charged Essense of Hatred
-  bet: `${RED}**  ${ORANGE}Burning Essence of Terror  ${RED}**`,        // Burning Essence of Terror
-  fed: `${RED}**  ${ORANGE}Festering Essence of Destruction  ${RED}**`, // Festering Essence of Destruction
-  toa: `${RED}*****   ${ORANGE}Token of Absolution   ${RED}*****`,          // Token of Absolution
+  tes: `${RED}**${ORANGE}  Twisted Essence of Suffering  ${RED}**${ORANGE}`,     // Twisted Essence of Suffering
+  ceh: `${RED}**${ORANGE}  Charged Essense of Hatred  ${RED}**${ORANGE}`,        // Charged Essense of Hatred
+  bet: `${RED}**${ORANGE}  Burning Essence of Terror  ${RED}**${ORANGE}`,        // Burning Essence of Terror
+  fed: `${RED}**${ORANGE}  Festering Essence of Destruction  ${RED}**${ORANGE}`, // Festering Essence of Destruction
+  toa: `${RED}*****${ORANGE}   Token of Absolution   ${RED}*****${ORANGE}`,          // Token of Absolution
 
   //=================//
   //   Quest Items   //
   //=================//
   // Act 1
-  leg: `${RED}**********     ${GOLD}Wirt's Leg     ${RED}**********`,           // Wirt's Leg
-  hdm: `${RED}**********     ${GOLD}Horadric Malus     ${RED}**********`,       // Horadric Malus
-  bks: `${RED}**********     ${GOLD}Scroll of Inifuss     ${RED}**********`,    // Scroll of Inifuss
-  bkd: `${RED}**********     ${GOLD}Scroll of Inifuss     ${RED}**********`,    // Scroll of Inifuss (deciphered)
+  leg: `${RED}**********${GOLD}     Wirt's Leg     ${RED}**********${GOLD}`,           // Wirt's Leg
+  hdm: `${RED}**********${GOLD}     Horadric Malus     ${RED}**********${GOLD}`,       // Horadric Malus
+  bks: `${RED}**********${GOLD}     Scroll of Inifuss     ${RED}**********${GOLD}`,    // Scroll of Inifuss
+  bkd: `${RED}**********${GOLD}     Scroll of Inifuss     ${RED}**********${GOLD}`,    // Scroll of Inifuss (deciphered)
   // Act 2
-  ass: `${RED}**********     ${GOLD}Book of Skill     ${RED}**********`,        // Book of Skill
-  box: `${RED}**********     ${GOLD}Horadric Cube     ${RED}**********`,        // Horadric Cube
-  tr1: `${RED}**********     ${GOLD}Horadric Scroll     ${RED}**********`,      // Horadric Scroll
-  msf: `${RED}**********     ${GOLD}Staff of Kings     ${RED}**********`,       // Staff of Kings
-  vip: `${RED}**********     ${GOLD}Amulet of the Viper     ${RED}**********`,  // Amulet of the Viper
-  hst: `${RED}**********     ${GOLD}Horadric Staff     ${RED}**********`,       // Horadric Staff
+  ass: `${RED}**********${GOLD}     Book of Skill     ${RED}**********${GOLD}`,        // Book of Skill
+  box: `${RED}**********${GOLD}     Horadric Cube     ${RED}**********${GOLD}`,        // Horadric Cube
+  tr1: `${RED}**********${GOLD}     Horadric Scroll     ${RED}**********${GOLD}`,      // Horadric Scroll
+  msf: `${RED}**********${GOLD}     Staff of Kings     ${RED}**********${GOLD}`,       // Staff of Kings
+  vip: `${RED}**********${GOLD}     Amulet of the Viper     ${RED}**********${GOLD}`,  // Amulet of the Viper
+  hst: `${RED}**********${GOLD}     Horadric Staff     ${RED}**********${GOLD}`,       // Horadric Staff
   // Act 3
-  xyz: `${RED}**********     ${GOLD}Potion of Life     ${RED}**********`,       // Potion of Life
-  j34: `${RED}**********     ${GOLD}A Jade Figurine     ${RED}**********`,      // A Jade Figurine
-  g34: `${RED}**********     ${GOLD}The Golden Bird     ${RED}**********`,      // The Golden Bird
-  bbb: `${RED}**********     ${GOLD}Lam Esen's Tome     ${RED}**********`,      // Lam Esen's Tome
-  g33: `${RED}**********     ${GOLD}The Gidbinn     ${RED}**********`,          // The Gidbinn
-  qf1: `${RED}**********     ${GOLD}Khalim's Flail     ${RED}**********`,       // Khalim's Flail
-  qf2: `${RED}**********     ${GOLD}Khalim's Will     ${RED}**********`,        // Khalim's Will
-  qey: `${RED}**********     ${GOLD}Khalim's Eye     ${RED}**********`,         // Khalim's Eye
-  qhr: `${RED}**********     ${GOLD}Khalim's Heart     ${RED}**********`,       // Khalim's Heart
-  qbr: `${RED}**********     ${GOLD}Khalim's Brain     ${RED}**********`,       // Khalim's Brain
-  mss: `${RED}**********     ${GOLD}Mephisto's Soulstone     ${RED}**********`, // Mephisto's Soulstone
+  xyz: `${RED}**********${GOLD}     Potion of Life     ${RED}**********${GOLD}`,       // Potion of Life
+  j34: `${RED}**********${GOLD}     A Jade Figurine     ${RED}**********${GOLD}`,      // A Jade Figurine
+  g34: `${RED}**********${GOLD}     The Golden Bird     ${RED}**********${GOLD}`,      // The Golden Bird
+  bbb: `${RED}**********${GOLD}     Lam Esen's Tome     ${RED}**********${GOLD}`,      // Lam Esen's Tome
+  g33: `${RED}**********${GOLD}     The Gidbinn     ${RED}**********${GOLD}`,          // The Gidbinn
+  qf1: `${RED}**********${GOLD}     Khalim's Flail     ${RED}**********${GOLD}`,       // Khalim's Flail
+  qf2: `${RED}**********${GOLD}     Khalim's Will     ${RED}**********${GOLD}`,        // Khalim's Will
+  qey: `${RED}**********${GOLD}     Khalim's Eye     ${RED}**********${GOLD}`,         // Khalim's Eye
+  qhr: `${RED}**********${GOLD}     Khalim's Heart     ${RED}**********${GOLD}`,       // Khalim's Heart
+  qbr: `${RED}**********${GOLD}     Khalim's Brain     ${RED}**********${GOLD}`,       // Khalim's Brain
+  mss: `${RED}**********${GOLD}     Mephisto's Soulstone     ${RED}**********${GOLD}`, // Mephisto's Soulstone
   // Act 4
-  hfh: `${RED}**********     ${GOLD}Hellforge Hammer     ${RED}**********`,     // Hellforge Hammer
+  hfh: `${RED}**********${GOLD}     Hellforge Hammer     ${RED}**********${GOLD}`,     // Hellforge Hammer
   // Act 5
-  ice: `${RED}**********     ${GOLD}Malah's Potion     ${RED}**********`,       // Malah's Potion
-  tr2: `${RED}**********     ${GOLD}Scroll of Resistance     ${RED}**********`, // Scroll of Resistance
+  ice: `${RED}**********${GOLD}     Malah's Potion     ${RED}**********${GOLD}`,       // Malah's Potion
+  tr2: `${RED}**********${GOLD}     Scroll of Resistance     ${RED}**********${GOLD}`, // Scroll of Resistance
+
+  // Extra
+  LamTome:          `${RED}**********${GOLD}     Lam Esen's Tome     ${RED}**********${GOLD}`, // Lam Esen's Tome
+  KhalimFlail:      `${RED}**********${GOLD}     Khalim's Flail     ${RED}**********${GOLD}`,  // Khalim's Flail
+  SuperKhalimFlail: `${RED}**********${GOLD}     Khalim's Will     ${RED}**********${GOLD}`,   // Khalim's Will
+};
+
+customItems["Staff of Kings"]      = `${RED}**********${GOLD}     Staff of Kings     ${RED}**********${GOLD}`;      // Staff of Kings
+customItems["Amulet of the Viper"] = `${RED}**********${GOLD}     Amulet of the Viper     ${RED}**********${GOLD}`; // Amulet of the Viper
+customItems["Horadric Staff"]      = `${RED}**********${GOLD}     Horadric Staff     ${RED}**********${GOLD}`;      // Horadric Staff
+customItems["Hell Forge Hammer"]   = `${RED}**********${GOLD}     Hell Forge Hammer     ${RED}**********${GOLD}`;   // Hellforge Hammer
+
+
+//===============//
+//   Custom UI   //
+//===============//
+const customUi = {
+
+  //=================//
+  //   Quest Items   //
+  //=================//
+  // For some reason, the devs put these gems in the wrong JSON file.
+  ass: `${RED}**********${GOLD}     Book of Skill     ${RED}**********${GOLD}`,  // Book of Skill
+  xyz: `${RED}**********${GOLD}     Potion of Life     ${RED}**********${GOLD}`, // Potion of Life
 };
 
 
@@ -286,6 +319,7 @@ function applyItemNameMods() {
   }
   if (config.IsItemsEnabled) {
     applyCustomNames(itemNamesPath, customItems);
+    applyCustomNames(uiPath, customUi);
   }
 }
 

--- a/CaedendiSimpleLootFilter/mod.json
+++ b/CaedendiSimpleLootFilter/mod.json
@@ -3,8 +3,14 @@
   "description": "Adds a simple customizable loot filter to Diablo 2: Resurrected using D2RMM.",
   "author": "Caedendi",
   "website": "https://www.nexusmods.com/diablo2resurrected/mods/360",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "config": [
+    {
+      "id": "ItemsSection",
+      "type": "section",
+      "name": "Items",
+      "defaultExpanded": false
+    },
     {
       "id": "IsGoldEnabled",
       "type": "checkbox",
@@ -20,18 +26,66 @@
       "defaultValue": true
     },
     {
-      "id": "IsItemsEnabled",
+      "id": "IsJunkEnabled",
       "type": "checkbox",
-      "name": "Items",
+      "name": "Junk",
       "description": "Shrink, highlight and color the tooltips for potions, scrolls/tomes, bolts/arrows, gems, essences/tokens, Pandomonium Event and quest items.",
       "defaultValue": true
     },
     {
-      "id": "IsCubeEnabled",
+      "id": "IsGemsEnabled",
+      "type": "checkbox",
+      "name": "Gems",
+      "description": "Customize the tooltips for gems.",
+      "defaultValue": true
+    },
+    {
+      "id": "IsJewelryEnabled",
+      "type": "checkbox",
+      "name": "Jewelry",
+      "description": "Customize the tooltips for amulets, rings and jewels.",
+      "defaultValue": true
+    },
+    {
+      "id": "IsCharmsEnabled",
+      "type": "checkbox",
+      "name": "Charms",
+      "description": "Customize the tooltips for charms.",
+      "defaultValue": true
+    },
+    {
+      "id": "IsQuestEnabled",
+      "type": "checkbox",
+      "name": "Quest Items",
+      "description": "Customize the tooltips for quest items.",
+      "defaultValue": true
+    },
+    {
+      "id": "ShouldExcludeCube",
       "type": "checkbox",
       "name": "Exclude Horadric Cube",
-      "description": "Exclude Horadric Cube highlighting to prevent ",
+      "description": "Exclude Horadric Cube highlighting to fix messing up the cube window's title and some NPC dialog where it is mentioned.",
       "defaultValue": true
+    },
+    {
+      "id": "IsEndgameEnabled",
+      "type": "checkbox",
+      "name": "Endgame Items",
+      "description": "Customize the tooltips for keys, organs, essences, token of absolution and standard of heroes.",
+      "defaultValue": true
+    },
+    {
+      "id": "ShortSupInf",
+      "type": "checkbox",
+      "name": "Short Superior/Inferior Prefixes",
+      "description": "Shorten the Superior/Damaged/Cracked/Crude/Low Quality modifiers on weapons and armor to + (plus) and - (minus/dash). Works the same as mod Short Quality Prefixes by Jobus.",
+      "defaultValue": true
+    },
+    {
+      "id": "TooltipSection",
+      "type": "section",
+      "name": "Tooltip Mods",
+      "defaultExpanded": false
     },
     {
       "id": "HiddenItemTooltipSize",

--- a/CaedendiSimpleLootFilter/mod.json
+++ b/CaedendiSimpleLootFilter/mod.json
@@ -27,6 +27,13 @@
       "defaultValue": true
     },
     {
+      "id": "IsCubeEnabled",
+      "type": "checkbox",
+      "name": "Exclude Horadric Cube",
+      "description": "Exclude Horadric Cube highlighting to prevent ",
+      "defaultValue": true
+    },
+    {
       "id": "HiddenItemTooltipSize",
       "type": "number",
       "name": "Tooltip width for hidden items",

--- a/CaedendiSimpleLootFilter/mod.json
+++ b/CaedendiSimpleLootFilter/mod.json
@@ -29,7 +29,7 @@
       "id": "IsJunkEnabled",
       "type": "checkbox",
       "name": "Junk",
-      "description": "Shrink, highlight and color the tooltips for potions, scrolls/tomes, bolts/arrows, gems, essences/tokens, Pandomonium Event and quest items.",
+      "description": "Shrink, highlight and color the tooltips for potions, scrolls/tomes, bolts/arrows and keys.",
       "defaultValue": true
     },
     {

--- a/README.md
+++ b/README.md
@@ -2,24 +2,29 @@
 
 _See also: [Caedendi's Extended Loot Filter for D2RMM](https://github.com/Caedendi/D2RMM-Loot-Filter-Extended)_
 
-Adds a simple customizable loot filter to Diablo 2: Resurrected using D2RMM. <br>
+Adds a simple customizable loot filter to Diablo II: Resurrected using D2RMM. <br>
 Cleans up item names to remove clutter and emphasizes important items. For the full feature list, see below.
 
 Recommended for those who want a quick and simple template to modify themselves. <br>
-If you don't want to modify .js files and rather have a shitload of presets, see the Extended version above.
+If you don't want to modify .js files and rather have a shitload of presets, see the Extended version at the bottom of the page.
 
 
 ## Table of Contents
 
 - [Screenshots](#screenshots)
+- [Changelog](#changelog)
+  - [2.0.0](#200)
+  - [1.0.0](#100)
+- [How to Install](#how-to-install)
 - [Features](#features)
-- [Installation](#installation)
-- [Recommended Mods](#recommended-mods)
 - [Roadmap](#roadmap)
+- [Recommended Mods](#recommended-mods)
+- [License/Permissions](#licensepermissions)
 - [Credits](#credits)
   - [Code](#code)
   - [Filter Style](#filter-style)
-- [License/Permissions](#licensepermissions)
+- [My Mods + Source](#my-mods--source)
+  - [Diablo II: Resurrected](#diablo-ii-resurrected)
 
 
 ## Screenshots
@@ -32,6 +37,35 @@ If you don't want to modify .js files and rather have a shitload of presets, see
 <p float="left">
     <img src="https://i.imgur.com/7jkSd0G.png" alt="03_runes_numbers_highlights_no-affix" width="49%">
 </p>
+
+
+## Changelog
+
+### 2.0.0
+
+- The mod settings menu is now divided into sections. Make sure to use D2RMM 1.4.6 or higher!
+- Fixed half of the quest items not having highlighting patterns
+- Fixed the cube window's title being all messy when highlighting quest items is enabled by adding an option to exclude the cube
+- Fixed Hell Forge Hammer incorrectly displaying as "Hellforge Hammer" when highlighting is enabled
+- Fixed some gem names not being filtered correctly
+- Fixed bugged support for charms and added highlighting of id'd uniques
+- Removed bugged support for jewels, rings and amulets as they can't be fixed
+- Changed Small/Full Rejuvenation Potion name from +SRP/+FRP to +RPS/+RPF
+- Improved highlight patterns
+- Added highlighting to Rainbow Facets
+- Added built-in short superior/inferior prefixes mod
+
+### 1.0.0
+
+First official release!
+
+
+## How to Install
+
+- Download and install [D2RMM](https://www.nexusmods.com/diablo2resurrected/mods/169), then run it.
+- Download and extract this mod folder to /D2RMM/mods/.
+- See D2RMM instructions on how to configure and enable.
+- Play the game!
 
 
 ## Features
@@ -47,37 +81,11 @@ If you don't want to modify .js files and rather have a shitload of presets, see
 - **Runes:** 
   - Remove the "Rune" affix, add rune numbers and highlight important runes.
 - **Items:** 
-  - Shrink, highlight and color the tooltips for potions, scrolls/tomes, bolts/arrows, gems, essences/tokens, Pandomonium Event and quest items.
-- **Jewelry:** (disabled because BUGGED)
-  - Highlight the tooltips for rings, amulets, jewels and charms.
-  - To enable, remove `//` from lines 126-132 in mod.js
-  - BUG: Crafted/rare/set/unique rings, amulets, jewels and charms now also have blue tooltips
+  - Shrink, highlight and color the tooltips for potions, scrolls/tomes, bolts/arrows, gems, charms, facets, essences/tokens, Pandomonium Event - and quest items.
+- **Short Superior/Inferior prefixes:** 
+  - Shorten superior/inferior prefixes to + and -.
 - **Item tooltip customization:**
   - Modify the size and background opacity of the tooltip for items on the ground and in the inventory.
-
-
-## Installation
-
-- Download and install [D2RMM](https://www.nexusmods.com/diablo2resurrected/mods/169), then run it.
-- Download and extract this mod folder to /D2RMM/mods/.
-- See D2RMM instructions on how to configure and enable.
-- Play the game!
-
-
-## Recommended Mods
-
-In addition to this, I recommend you also use the following D2RMM mods:
-
-| Mod                                                                             |   Creator   | Notes                                                                                              |
-|---------------------------------------------------------------------------------|:-----------:|----------------------------------------------------------------------------------------------------|
-| [Disable Battle.net](https://github.com/olegbl/d2rmm.mods)                      |   olegbl    | So you don't accidentally get yourself banned.                                                     |
-| [Settings Font Fix](https://www.nexusmods.com/diablo2resurrected/mods/200)      |   olegbl    | In case any mod touches __profilehd_ and screws up the font size in the settings menu.             |
-| [LightPillar](https://www.nexusmods.com/diablo2resurrected/mods/197)            |   qhu91it   | Add an awesome effect when certain items drop.                                                     |
-| [Skip Intro Videos](https://www.nexusmods.com/diablo2resurrected/mods/179)      |   olegbl    | On startup, gets you straight to the title screen.                                                 |
-| [Towns QoL Changes](https://www.nexusmods.com/diablo2resurrected/mods/310)      | night0wl117 | Move town starting points, TP locations and Cain's position in Act 5.                              |
-| [Town Cast](https://www.nexusmods.com/diablo2resurrected/mods/183)              |   olegbl    | Teleport and buff in town. _(BREAKING: allows teleporting past Jerhyn during the Act 2 questline)_ |
-| [Show Item Level](https://www.nexusmods.com/diablo2resurrected/mods/174)        |   olegbl    | Adds the ilvl to the tooltips of all items with an ilvl.                                           |
-| [Short Quality Prefixes](https://www.nexusmods.com/diablo2resurrected/mods/214) |    Jobus    | Shortens the Superior/Inferior prefixes _(will be added to this mod in a future update)_.          |
 
 
 ## Roadmap
@@ -91,24 +99,21 @@ In addition to this, I recommend you also use the following D2RMM mods:
   - [ ] Different emphasis for unique charms, rare jewels and facets (rainbow color)
 
 
-## Credits
+## Recommended Mods
 
-This loot filter mod is based on code from existing mods and inspired by existing styles. I have added code optimizations, toggles and my own personal flair and preferences. <br>
-Remnants of other people's codes remain, so I have tried to list the credits as accurately as I can. If you see any of your own code in this mod and it isn't credited, please send me a message.
+In addition to this, I recommend you also use the following D2RMM mods:
 
-Many thanks to:
-
-### Code
-- [Practical Item Filter for D2RMM](https://www.nexusmods.com/diablo2resurrected/mods/317) for acting as a base to build upon and the tooltip customization features
-- [olegbl](https://github.com/olegbl) for:
-  - Creating [D2RMM](https://www.nexusmods.com/diablo2resurrected/mods/169).
-  - His [example mods](https://github.com/olegbl/d2rmm.mods) in general.
-  - His [Short Potion Names](https://www.nexusmods.com/diablo2resurrected/mods/177) mod for the list of colors.
-
-### Filter Style
-- [Path of Diablo filters](https://pathofdiablo.com/wiki/index.php?title=List_of_Loot_Filters) for removing all that clutter on Path of Diablo and inspiring me to create this loot filter for D2R.
-  - Mainly [Darkgale](https://www.twitch.tv/darkgale)'s filter called [Filtergale](https://www.reddit.com/r/pathofdiablo/comments/i9hdw7/filtergale/) ([download](https://greendu.de/s/ZbDwHekAg3rmeRB/download?path=%2F&files=item.filter)) regarding styling.
-- [Practical Item Filter for D2RMM](https://www.nexusmods.com/diablo2resurrected/mods/317)
+| Mod                                                                                  |                                                   Creator                                                    | Notes                                                                                              |
+|--------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------------------------------:|----------------------------------------------------------------------------------------------------|
+| [Disable Battle.net](https://github.com/olegbl/d2rmm.mods)                           |                                     [olegbl](https://github.com/olegbl)                                      | So you don't accidentally get yourself banned.                                                     |
+| [Skip Videos](https://www.nexusmods.com/diablo2resurrected/mods/179)                 |                [Caedendi](https://www.nexusmods.com/diablo2resurrected/users/179695179) (me)                 | Disable launch intro videos and cinematic cutscenes when transitioning between acts.               |
+| [Improved Potion Visibility](https://www.nexusmods.com/diablo2resurrected/mods/384)  |                   [MetalTxus](https://www.nexusmods.com/diablo2resurrected/users/18894694)                   | Changes healing/mana potion sprites so it's easier to distinguish different potion levels.         |
+| [UI Fixes](https://www.nexusmods.com/diablo2resurrected/mods/387)                    |                   [MetalTxus](https://www.nexusmods.com/diablo2resurrected/users/18894694)                   | Fixes the placement of a few item grids.                                                           |
+| [Towns QoL Changes](https://www.nexusmods.com/diablo2resurrected/mods/310)           |                  [night0wl117](https://www.nexusmods.com/diablo2resurrected/users/33697975)                  | Move town starting points, TP locations and Cain's position in Act 5.                              |
+| [Town Cast](https://www.nexusmods.com/diablo2resurrected/mods/183)                   |                                     [olegbl](https://github.com/olegbl)                                      | Teleport and buff in town. _(BREAKING: allows teleporting past Jerhyn during the Act 2 questline)_ |
+| [Show Item Level](https://www.nexusmods.com/diablo2resurrected/mods/174)             |                                     [olegbl](https://github.com/olegbl)                                      | Adds the ilvl to the tooltips of all items with an ilvl.                                           |
+| [LightPillar](https://www.nexusmods.com/diablo2resurrected/mods/197)                 | [qhu91it](https://github.com/qhu91it) and [buzh](https://www.nexusmods.com/diablo2resurrected/users/2596633) | Add an awesome effect when certain items drop.                                                     |
+| [Settings Font Fix](https://www.nexusmods.com/diablo2resurrected/mods/200)           |                                     [olegbl](https://github.com/olegbl)                                      | In case any mod touches __profilehd_ and screws up the font size in the settings menu.             |
 
 
 ## License/Permissions
@@ -118,3 +123,36 @@ This code is licensed under GPL.
 You are free to use and distribute all code in this mod, as long as you ask for permission (and permission is given), it stays open source, free of charge and all due credit is given. 
 
 If you are trying to profit off this mod in any way, then you're a dick and forbidden from using this code.
+
+
+## Credits
+
+This loot filter mod is based on code from existing mods and inspired by existing styles. I have added code optimizations, toggles and my own personal flair and preferences. <br>
+Remnants of other people's codes remain, so I have tried to list the credits as accurately as I can. If you see any of your own code in this mod and it isn't credited, please send me a message.
+
+Many thanks to:
+
+### Code
+- [salzgaard](https://www.nexusmods.com/diablo2resurrected/users/6397569) for his [Practical Item Filter for D2RMM](https://www.nexusmods.com/diablo2resurrected/mods/317), which acted as a base for this mod and the tooltip customization features.
+- [olegbl](https://github.com/olegbl) for
+  - Creating [D2RMM](https://www.nexusmods.com/diablo2resurrected/mods/169)
+  - His [example mods](https://github.com/olegbl/d2rmm.mods) in general
+  - His [Short Potion Names](https://www.nexusmods.com/diablo2resurrected/mods/177) mod for the list of colors
+- [Jobus](https://www.nexusmods.com/diablo2resurrected/users/3107665) for his [Short Quality Prefixes for D2RMM](https://www.nexusmods.com/diablo2resurrected/mods/214) mod, which I integrated
+
+### Filter Style
+- [Path of Diablo filters](https://pathofdiablo.com/wiki/index.php?title=List_of_Loot_Filters) for removing all that clutter on Path of Diablo and inspiring me to create this loot filter for D2R.
+  - Mainly [Darkgale](https://www.twitch.tv/darkgale)'s filter called [Filtergale](https://www.reddit.com/r/pathofdiablo/comments/i9hdw7/filtergale/) ([download](https://greendu.de/s/ZbDwHekAg3rmeRB/download?path=%2F&files=item.filter)) regarding styling.
+- [Practical Item Filter for D2RMM](https://www.nexusmods.com/diablo2resurrected/mods/317)
+- [Cbraqz](https://www.nexusmods.com/diablo2resurrected/users/3106975)'s [D2R Simple Loot Filter](https://www.nexusmods.com/diablo2resurrected/mods/54) mod for giving me an idea on how to fix highlighting charms without removing rarity coloring
+
+
+## My Mods + Source ##
+
+### Diablo II: Resurrected ###
+
+| Nexus Mods Page                                                                                    | Source                                                           |
+|:---------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------|
+| [Caedendi's Extended Loot Filter for D2RMM](https://www.nexusmods.com/diablo2resurrected/mods/361) | [GitHub](https://github.com/Caedendi/D2RMM-Loot-Filter-Extended) |
+| [Caedendi's Simple Loot Filter for D2RMM](https://www.nexusmods.com/diablo2resurrected/mods/360)   | [GitHub](https://github.com/Caedendi/D2RMM-Loot-Filter-Simple)   |
+| [Skip Videos for D2RMM](https://www.nexusmods.com/diablo2resurrected/mods/397)                     | [GitHub](https://github.com/Caedendi/D2RMM-Skip-Videos)          |

--- a/README.md
+++ b/README.md
@@ -90,13 +90,16 @@ First official release!
 
 ## Roadmap
 
-- [ ] Fix known bugs:
-  - [x] Regular Ruby, Sapphire, Emerald and Diamond not working
-  - [ ] Enabling jewelry turns crafted/rare/set/unique jewelry blue
-- [ ] Add features:
-  - [ ] Integrate [Show Item Level](https://www.nexusmods.com/diablo2resurrected/mods/174) by olegbl
-  - [ ] Integrate [Short Quality Prefixes for D2RMM](https://www.nexusmods.com/diablo2resurrected/mods/214/?tab=files&category=archived) or [Show Item Quality for D2RMM](https://www.nexusmods.com/diablo2resurrected/mods/351)
-  - [ ] Different emphasis for unique charms, rare jewels and facets (rainbow color)
+### Fix known bugs
+
+- [x] Regular Ruby, Sapphire, Emerald and Diamond not working
+- [x] Certain quest item customization not working
+- [x] Enabling quest item highlighting screws up the Horadric Cube's displayed name when the cube menu is open.
+- [x] Enabling jewelry turns crafted/rare/set/unique jewelry blue
+
+### Add features
+
+- [x] Integrate [Short Quality Prefixes for D2RMM](https://www.nexusmods.com/diablo2resurrected/mods/214) by [Jobus](https://www.nexusmods.com/diablo2resurrected/users/3107665)
 
 
 ## Recommended Mods

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ First official release!
 ## Features
 
 - **Customize to your liking:**
-  - Use this filter as a template to apply your own custom naming schemes. Just open the mod.js file in Notepad and change whatever items you'd like.
+  - Use this filter as a template to apply your own custom naming schemes. Just open the mod.js file in Notepad or VSCodium and change whatever items you'd like.
   - To hide an item, change its name to HIDDEN (without quotes). The value of HIDDEN (amount of spaces) can be changed in the D2RMM settings.
   - Don't forget to reload and apply in D2RMM!
 - **Completely optional:** 

--- a/README.md
+++ b/README.md
@@ -74,18 +74,12 @@ First official release!
   - Use this filter as a template to apply your own custom naming schemes. Just open the mod.js file in Notepad or VSCodium and change whatever items you'd like.
   - To hide an item, change its name to HIDDEN (without quotes). The value of HIDDEN (amount of spaces) can be changed in the D2RMM settings.
   - Don't forget to reload and apply in D2RMM!
-- **Completely optional:** 
-  - Untoggling everything means no modding will be applied
-- **Gold:** 
-  - Shrink the "Gold"-affix to a gold-colored "G".
-- **Runes:** 
-  - Remove the "Rune" affix, add rune numbers and highlight important runes.
-- **Items:** 
-  - Shrink, highlight and color the tooltips for potions, scrolls/tomes, bolts/arrows, gems, charms, facets, essences/tokens, Pandomonium Event - and quest items.
-- **Short Superior/Inferior prefixes:** 
-  - Shorten superior/inferior prefixes to + and -.
-- **Item tooltip customization:**
-  - Modify the size and background opacity of the tooltip for items on the ground and in the inventory.
+- **Completely optional:** Untoggling everything means no modding will be applied.
+- **Gold:** Shrink the "Gold"-affix to a gold-colored "G".
+- **Runes:** Remove the "Rune" affix, add rune numbers and highlight important runes.
+- **Items:** Shrink, highlight and color the tooltips for potions, scrolls/tomes, bolts/arrows, gems, charms, facets, essences/tokens, Pandomonium Event - and quest items.
+- **Short Superior/Inferior prefixes:** Shorten superior/inferior prefixes to + and -.
+- **Item tooltip customization:** Modify the size and background opacity of the tooltip for items on the ground and in the inventory.
 
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ In addition to this, I recommend you also use the following D2RMM mods:
 - [ ] Add features:
   - [ ] Integrate [Show Item Level](https://www.nexusmods.com/diablo2resurrected/mods/174) by olegbl
   - [ ] Integrate [Short Quality Prefixes for D2RMM](https://www.nexusmods.com/diablo2resurrected/mods/214/?tab=files&category=archived) or [Show Item Quality for D2RMM](https://www.nexusmods.com/diablo2resurrected/mods/351)
-  - [ ] different emphasis for unique charms, rare jewels and facets (rainbow color)
+  - [ ] Different emphasis for unique charms, rare jewels and facets (rainbow color)
 
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ First official release!
 
 ## Roadmap
 
+None at the moment. If you have a request for a feature, please open a GitHub issue (preferred) or post a comment on Nexus Mods.
+
 ### Fix known bugs
 
 - [x] Regular Ruby, Sapphire, Emerald and Diamond not working


### PR DESCRIPTION
- The mod settings menu is now divided into sections. Make sure to use D2RMM 1.4.6 or higher!
- Fixed half of the quest items not having highlighting patterns
- Fixed the cube window's title being all messy when highlighting quest items is enabled by adding an option to exclude the cube
- Fixed Hell Forge Hammer incorrectly displaying as "Hellforge Hammer" when highlighting is enabled
- Fixed some gem names not being filtered correctly
- Fixed bugged support for charms and added highlighting of id'd uniques
- Removed bugged support for jewels, rings and amulets as they can't be fixed
- Changed Small/Full Rejuvenation Potion name from +SRP/+FRP to +RPS/+RPF
- Improved highlight patterns
- Added highlighting to Rainbow Facets
- Added built-in short superior/inferior prefixes mod